### PR TITLE
Fix README run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,7 @@ Install Python 3.9+ and the requirements (pip install -r requirements.txt)
 
 Run the app:
 
-arduino
-Copy
-Edit
-streamlit run <your_script_name.py>
+streamlit run PGx_CDS_Dashboard_V1.py
 Upload a PGx report (PDF or TXT) and select medications to get started.
 
 Next Steps


### PR DESCRIPTION
## Summary
- clean stray words in the Run section
- point Streamlit command at provided script

## Testing
- `python3 -m py_compile PGx_CDS_Dashboard_V1.py`

------
https://chatgpt.com/codex/tasks/task_e_6840704512948320bd2b3380d0e2a62c